### PR TITLE
Package dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,13 @@ FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --allow-downgrades \
+    libdpkg-perl=1.19.7ubuntu3 \
     dpkg-dev=1.19.7ubuntu3 \
     g++-9=9.4.0-1ubuntu1~20.04.1 \
     gcc-9=9.4.0-1ubuntu1~20.04.1 \
+    libc6=2.31-0ubuntu9.7 \
+    libc-dev-bin=2.31-0ubuntu9.7 \
     libc6-dev=2.31-0ubuntu9.7 \
     make=4.2.1-1.2 \
     cmake=3.16.3-1ubuntu1 \

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Please document any official changes in the [CHANGELOG.md](CHANGELOG.md) file. W
 
 ## About
 
-Version: 0.1.0
+Version: 0.1.1

--- a/run_interactive_container.sh
+++ b/run_interactive_container.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=$(cat README.md | grep "Version" | awk '{print $2}')
+VERSION=$(cat README.md | grep "Version:" | awk '{print $2}')
 
 docker run \
     --rm \


### PR DESCRIPTION
Force `apt` to download the right versions of some packages upon which `dpkg-dev` and `libc6` depend.